### PR TITLE
Fixes #16. Invalid prop `activityIndicatorSize`

### DIFF
--- a/src/ProgressDialog.js
+++ b/src/ProgressDialog.js
@@ -55,7 +55,7 @@ ProgressDialog.propTypes = {
     message: PropTypes.string.isRequired,
     messageStyle: Text.propTypes.style,
     activityIndicatorColor: PropTypes.string,
-    activityIndicatorSize: PropTypes.number,
+    activityIndicatorSize: PropTypes.string,
     activityIndicatorStyle: ViewPropTypes.style
 }
 


### PR DESCRIPTION
Exact error: Invalid prop `activityIndicatorSize` of type `string` supplied to `ProgressDialog`, expected `number`.
Wrong propType supplied.