### PR TITLE
Center dialog on screen

### DIFF
--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -63,7 +63,8 @@ class Dialog extends Component {
                     color: "#000000DD",
                     fontSize: 20,
                     margin: 24,
-                    marginBottom: 0
+                    marginBottom: 0,
+                    alignItems: "center"
                 }, titleStyle]}>
                     {title}
                 </Text>


### PR DESCRIPTION
Center the Dialog on screen after setting the width of dialogStyle, otherwise the dialog will be left aligned.

For example:
dialogStyle={{width:'40%', minWidth: 200}}