### PR TITLE
Align propTypes with types accepted by ActivityIndicator `size`

### DIFF
--- a/src/ProgressDialog.js
+++ b/src/ProgressDialog.js
@@ -55,7 +55,10 @@ ProgressDialog.propTypes = {
     message: PropTypes.oneOfType([PropTypes.string, PropTypes.element]).isRequired,
     messageStyle: Text.propTypes.style,
     activityIndicatorColor: PropTypes.string,
-    activityIndicatorSize: PropTypes.string,
+    activityIndicatorSize: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number
+    ]),
     activityIndicatorStyle: ViewPropTypes.style
 }
 


### PR DESCRIPTION
ActivityIndicator size property accepts String and Number (Andriod)
  * Change activityIndicatorSize propTypes to String and Number

Previously, changed propType from Number to String, but since there may be someone using Android who wants to use a Number instead, this PR includes BOTH String and Number as permissible input types for activityIndicatorSize.