### PR TITLE
Disable bouncing on Scrollview

### DIFF
--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -125,6 +125,7 @@ class Dialog extends Component {
                 supportedOrientations={supportedOrientations}
             >
                 <ScrollView
+                    bounces={false}
                     style={{
                         flex: 1,
                     }}


### PR DESCRIPTION
By default the Scrollview can be overscrolled in iOS. This couses the Overlay to leave the Screen boundries.