### PR TITLE
iPhoneX ScrollView offset

### DIFF
--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -134,6 +134,7 @@ class Dialog extends Component {
                     }}
                     keyboardDismissMode={keyboardDismissMode}
                     keyboardShouldPersistTaps={keyboardShouldPersistTaps}
+                    contentInsetAdjustmentBehavior="never"
                 >
                     <View style={[{
                         flex: 1,


### PR DESCRIPTION
ScrollView adds offset above and below the ScrollView equal to the StatusBar height on iPhoneX.

I don't know if this is unique to React Native Navigation [ScrollView content always offsets from top by statusbarheight in iOS](https://github.com/wix/react-native-navigation/issues/3821), but I didn't see any negative effects running this on an iPhone 7/X without that package. 

Added `contentInsetAdjustmentBehavior="never"` to the Dialog ScrollView component.

This is an iOS-only prop so I did not test on Android, but if there are any side-effects known for this, it could be an optional prop instead. I just didn't produce any side-effects and I saw the previous PR statically disabled bounces so I followed that lead. 
