### PR TITLE
Fix "Can't lowercase the button titles on Android" bug

### DIFF
--- a/src/ConfirmDialog.js
+++ b/src/ConfirmDialog.js
@@ -1,25 +1,25 @@
 /**
 * MIT License
-* 
+*
 * Copyright (c) 2017 Douglas Nassif Roma Junior
-* 
+*
 * Permission is hereby granted, free of charge, to any person obtaining a copy
 * of this software and associated documentation files (the "Software"), to deal
 * in the Software without restriction, including without limitation the rights
 * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 * copies of the Software, and to permit persons to whom the Software is
 * furnished to do so, subject to the following conditions:
-* 
+*
 * The above copyright notice and this permission notice shall be included in all
 * copies or substantial portions of the Software.
-* 
+*
 * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-* SOFTWARE. 
+* SOFTWARE.
 */
 
 import React, { Component } from 'react'
@@ -79,6 +79,7 @@ class ConfirmDialog extends Component {
                 textAlignVertical: "center",
                 color: (!disabled ? color : (colorDisabled || color)) || DEFAULT_COLOR_BUTTON,
                 fontWeight: "bold",
+                textTransform: "uppercase",
                 ...othersStyle
             }
         });
@@ -97,10 +98,6 @@ class ConfirmDialog extends Component {
         if (button) {
             const { onPress, disabled, color, } = button;
 
-            const title = OS === 'ios' ?
-                button.title :
-                button.title.toUpperCase();
-
             const containerStyle = this.getButtonStyle(button, positive);
 
             const textStyle = this.getButtonTextStyle(button, positive);
@@ -112,7 +109,7 @@ class ConfirmDialog extends Component {
             return (
                 <TouchableEffect onPress={onPress} disabled={disabled} style={touchableStyle}>
                     <View style={containerStyle}>
-                        <Text style={textStyle} >{title}</Text>
+                        <Text style={textStyle} >{button.title}</Text>
                     </View>
                 </TouchableEffect>
             )


### PR DESCRIPTION
On Android, the buttons are always on uppercase. 

It is not possible to lowercase their titles, even applying a `textTransform: 'none'` to them.

More details on https://github.com/douglasjunior/react-native-simple-dialogs/issues/51.