### PR TITLE
Fixed a bug preventing vertical scrolling on dialogs.

### DIFF
--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -130,7 +130,7 @@ class Dialog extends Component {
                         flex: 1,
                     }}
                     contentContainerStyle={{
-                        flex: 1,
+                        minHeight: '100%',
                     }}
                     keyboardDismissMode={keyboardDismissMode}
                     keyboardShouldPersistTaps={keyboardShouldPersistTaps}


### PR DESCRIPTION
Dialog.js has a ScrollView for vertical scrolling, but it does not seem to work. When a dialog has large amount of content, it gets cut off at the bottom and cannot be scrolled. This simple change fixes that issue.

Without this change (scrolling does not work):

<img src="https://user-images.githubusercontent.com/98849998/164500322-22a6729b-9e78-419b-ac87-e2e50b514998.png" width="300" alt="Screenshot without change" />


With this change (scrolling does work):

<img src="https://user-images.githubusercontent.com/98849998/164500369-607f671d-c774-4392-baba-0139414850f9.png"  width="300" alt="First screenshot with change" />
<img src="https://user-images.githubusercontent.com/98849998/164500393-2bdbee14-2c6e-4a73-8f53-ddab47d8eedf.png" width="300" alt="Second screenshot with change" />