### PR TITLE
Improved sizing for ConfirmDialogs that contain ScrollViews 

### DIFF
--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -130,7 +130,7 @@ class Dialog extends Component {
                         flex: 1,
                     }}
                     contentContainerStyle={{
-                        minHeight: '100%',
+                        flex: 1,
                     }}
                     keyboardDismissMode={keyboardDismissMode}
                     keyboardShouldPersistTaps={keyboardShouldPersistTaps}

--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -44,6 +44,7 @@ class Dialog extends Component {
         return (
             <View style={[{
                 width: '100%',
+                flex: -1,
                 padding: 24,
                 paddingTop: 20
             }, contentStyle]}>
@@ -146,6 +147,7 @@ class Dialog extends Component {
                         <View style={[{
                             backgroundColor: dialogBackgroundColor,
                             width: '100%',
+                            maxHeight: '100%',
                             shadowOpacity: 0.24,
                             borderRadius: dialogBorderRadius,
                             elevation: 4,

--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -30,6 +30,7 @@ import {
     TouchableWithoutFeedback,
     Text,
     Platform,
+    SafeAreaView,
     ScrollView
 } from 'react-native'
 const { OS } = Platform;
@@ -142,30 +143,32 @@ class Dialog extends Component {
                         backgroundColor: "#000000AA",
                         padding: 24
                     }, overlayStyle]}>
-                        {this._renderOutsideTouchable(onTouchOutside)}
+                        <SafeAreaView style={{flex: 1}}>
+                            {this._renderOutsideTouchable(onTouchOutside)}
 
-                        <View style={[{
-                            backgroundColor: dialogBackgroundColor,
-                            width: '100%',
-                            maxHeight: '100%',
-                            shadowOpacity: 0.24,
-                            borderRadius: dialogBorderRadius,
-                            elevation: 4,
-                            shadowOffset: {
-                                height: 4,
-                                width: 2
-                            }
-                        }, dialogStyle]}>
+                            <View style={[{
+                                backgroundColor: dialogBackgroundColor,
+                                width: '100%',
+                                maxHeight: '100%',
+                                shadowOpacity: 0.24,
+                                borderRadius: dialogBorderRadius,
+                                elevation: 4,
+                                shadowOffset: {
+                                    height: 4,
+                                    width: 2
+                                }
+                            }, dialogStyle]}>
 
-                            {this.renderTitle()}
+                                {this.renderTitle()}
 
-                            {this.renderContent()}
+                                {this.renderContent()}
 
-                            {this.renderButtons()}
+                                {this.renderButtons()}
 
-                        </View>
+                            </View>
 
-                        {this._renderOutsideTouchable(onTouchOutside)}
+                            {this._renderOutsideTouchable(onTouchOutside)}
+                        </SafeAreaView>
                     </View>
                 </ScrollView>
             </Modal>

--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -44,7 +44,7 @@ class Dialog extends Component {
         return (
             <View style={[{
                 width: '100%',
-                flex: -1,
+                flexShrink: 1,
                 padding: 24,
                 paddingTop: 20
             }, contentStyle]}>

--- a/src/Dialog.js
+++ b/src/Dialog.js
@@ -130,7 +130,7 @@ class Dialog extends Component {
                         flex: 1,
                     }}
                     contentContainerStyle={{
-                        flex: 1,
+                        minHeight: '100%',
                     }}
                     keyboardDismissMode={keyboardDismissMode}
                     keyboardShouldPersistTaps={keyboardShouldPersistTaps}


### PR DESCRIPTION
ConfirmDialogs with a ScrollView containing a large amount of content are often displayed with a height larger than the available screen space, so that the bottom of the dialog is cut off:

<img src="https://user-images.githubusercontent.com/98849998/165131538-857203f4-4490-4252-83c5-8279ebdbe8f5.png" width="300" alt="Screenshot with existing code" />

This commit fixes that issue:

<img src="https://user-images.githubusercontent.com/98849998/165131542-8dc9ea47-c6b9-48da-8b30-fb9073d07ce3.png" width="300" alt="Screenshot with modified code" />

I have tested this on the Android emulator, but not on iOS yet.

The idea to use `flex: -1` comes from [medium.com/@peterpme/taming-react-natives-scrollview-with-flex-144e6ff76c08](https://medium.com/@peterpme/taming-react-natives-scrollview-with-flex-144e6ff76c08)

Here is the code for the demo dialog in the above screenshots:

```js
const [dialogVisible, setDialogVisible] = useState(false);
```
```js
<ConfirmDialog visible={dialogVisible}
  onTouchOutside={() => setDialogVisible(false)}
  onRequestClose={() => setDialogVisible(false)}
  negativeButton={{title: "Cancel", onPress: () => setDialogVisible(false)}}
  positiveButton={{title: "OK", onPress: () => setDialogVisible(false)}}>

  <ScrollView>
    <Text style={{fontSize: 18}}>1</Text>
    <Text style={{fontSize: 18}}>2</Text>
    <Text style={{fontSize: 18}}>3</Text>
    <Text style={{fontSize: 18}}>4</Text>
    <Text style={{fontSize: 18}}>5</Text>
    <Text style={{fontSize: 18}}>6</Text>
    <Text style={{fontSize: 18}}>7</Text>
    <Text style={{fontSize: 18}}>8</Text>
    <Text style={{fontSize: 18}}>9</Text>
    <Text style={{fontSize: 18}}>10</Text>
    <Text style={{fontSize: 18}}>11</Text>
    <Text style={{fontSize: 18}}>12</Text>
    <Text style={{fontSize: 18}}>13</Text>
    <Text style={{fontSize: 18}}>14</Text>
    <Text style={{fontSize: 18}}>15</Text>
    <Text style={{fontSize: 18}}>16</Text>
    <Text style={{fontSize: 18}}>17</Text>
    <Text style={{fontSize: 18}}>18</Text>
    <Text style={{fontSize: 18}}>19</Text>
    <Text style={{fontSize: 18}}>20</Text>
    <Text style={{fontSize: 18}}>21</Text>
    <Text style={{fontSize: 18}}>22</Text>
    <Text style={{fontSize: 18}}>23</Text>
    <Text style={{fontSize: 18}}>24</Text>
    <Text style={{fontSize: 18}}>25</Text>
    <Text style={{fontSize: 18}}>26</Text>
    <Text style={{fontSize: 18}}>27</Text>
    <Text style={{fontSize: 18}}>28</Text>
    <Text style={{fontSize: 18}}>29</Text>
    <Text style={{fontSize: 18}}>30</Text>
  </ScrollView>
</ConfirmDialog>
```