### PR TITLE
feat: replace default props by default value

### DIFF
--- a/src/ConfirmDialog.tsx
+++ b/src/ConfirmDialog.tsx
@@ -33,7 +33,7 @@ import {
   StyleSheet,
 } from 'react-native';
 
-import Dialog, {DialogPropsType} from './Dialog';
+import Dialog, {DialogPropsType, dialogDefaultProps} from './Dialog';
 import TouchableEffect from './TouchableEffect';
 
 const {OS} = Platform;
@@ -167,14 +167,19 @@ const getButtonTextStyle = (
   });
 };
 
-const ConfirmDialog = ({
-  children,
-  negativeButton,
-  positiveButton,
-  message,
-  messageStyle,
-  ...others
-}: ConfirmDialogPropsType): JSX.Element => {
+const ConfirmDialog = (props: ConfirmDialogPropsType): JSX.Element => {
+  const {
+    children,
+    negativeButton,
+    positiveButton,
+    message,
+    messageStyle,
+    ...others
+  } = {
+    ...dialogDefaultProps,
+    ...props,
+  };
+
   const renderMessage = () => {
     if (!message) {
       return null;
@@ -257,10 +262,6 @@ const ConfirmDialog = ({
       {renderContent()}
     </Dialog>
   );
-};
-
-ConfirmDialog.defaultProps = {
-  ...Dialog.defaultProps,
 };
 
 export default ConfirmDialog;

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -40,6 +40,12 @@ import {
 
 const {OS} = Platform;
 
+export const dialogDefaultProps = {
+  visible: false,
+  onRequestClose: () => null,
+  contentInsetAdjustmentBehavior: 'never',
+};
+
 export type DialogPropsType = {
   testID?: string;
   children?: React.ReactNode | React.ReactNode[];
@@ -73,38 +79,43 @@ export type DialogPropsType = {
   contentInsetAdjustmentBehavior: ScrollViewProps['contentInsetAdjustmentBehavior'];
 };
 
-const Dialog = ({
-  testID,
-  accessible,
-  accessibilityActions,
-  accessibilityLabel,
-  accessibilityRole,
-  accessibilityState,
-  accessibilityHint,
-  accessibilityValue,
-  onAccessibilityAction,
-  importantForAccessibility,
-  role,
-  children,
-  contentStyle,
-  title,
-  titleStyle,
-  buttons,
-  buttonsStyle,
-  dialogStyle,
-  visible,
-  animationType,
-  onRequestClose,
-  onShow,
-  onOrientationChange,
-  onTouchOutside,
-  overlayStyle,
-  supportedOrientations,
-  statusBarTranslucent,
-  keyboardDismissMode,
-  keyboardShouldPersistTaps,
-  contentInsetAdjustmentBehavior,
-}: DialogPropsType): JSX.Element => {
+const Dialog = (props: DialogPropsType): JSX.Element => {
+  const {
+    testID,
+    accessible,
+    accessibilityActions,
+    accessibilityLabel,
+    accessibilityRole,
+    accessibilityState,
+    accessibilityHint,
+    accessibilityValue,
+    onAccessibilityAction,
+    importantForAccessibility,
+    role,
+    children,
+    contentStyle,
+    title,
+    titleStyle,
+    buttons,
+    buttonsStyle,
+    dialogStyle,
+    visible,
+    animationType,
+    onRequestClose,
+    onShow,
+    onOrientationChange,
+    onTouchOutside,
+    overlayStyle,
+    supportedOrientations,
+    statusBarTranslucent,
+    keyboardDismissMode,
+    keyboardShouldPersistTaps,
+    contentInsetAdjustmentBehavior,
+  } = {
+    ...dialogDefaultProps,
+    ...props,
+  };
+
   const renderContent = () => {
     return (
       <View
@@ -253,12 +264,6 @@ const Dialog = ({
       </ScrollView>
     </Modal>
   );
-};
-
-Dialog.defaultProps = {
-  visible: false,
-  onRequestClose: () => null,
-  contentInsetAdjustmentBehavior: 'never',
 };
 
 export default Dialog;

--- a/src/ProgressDialog.tsx
+++ b/src/ProgressDialog.tsx
@@ -32,7 +32,7 @@ import {
   ActivityIndicatorProps,
 } from 'react-native';
 
-import Dialog, {DialogPropsType} from './Dialog';
+import Dialog, {DialogPropsType, dialogDefaultProps} from './Dialog';
 
 export type ProgressDialogPropsType = DialogPropsType & {
   message?: React.ReactNode;
@@ -42,14 +42,19 @@ export type ProgressDialogPropsType = DialogPropsType & {
   activityIndicatorStyle?: ActivityIndicatorProps['style'];
 };
 
-const ProgressDialog = ({
-  message,
-  messageStyle,
-  activityIndicatorColor,
-  activityIndicatorSize,
-  activityIndicatorStyle,
-  ...others
-}: ProgressDialogPropsType): JSX.Element => {
+const ProgressDialog = (props: ProgressDialogPropsType): JSX.Element => {
+  const {
+    message,
+    messageStyle,
+    activityIndicatorColor,
+    activityIndicatorSize,
+    activityIndicatorStyle,
+    ...others
+  } = {
+    ...dialogDefaultProps,
+    ...props,
+  };
+
   return (
     <Dialog {...others}>
       <View style={{flexDirection: 'row', alignItems: 'center'}}>
@@ -69,10 +74,6 @@ const ProgressDialog = ({
       </View>
     </Dialog>
   );
-};
-
-ProgressDialog.defaultProps = {
-  ...Dialog.defaultProps,
 };
 
 export default ProgressDialog;


### PR DESCRIPTION
Since React 19 stable version is around the corner, i think it is good to be fully compatible now with all of this changelog. 
In our case here this lib is using `defaultProps` and in the latest version of react native, warning is present each time that the component is mounted. 

As the guide for latest [react](https://react.dev/blog/2024/04/25/react-19-upgrade-guide) says:

> Removed deprecated React APIs 
> Removed: propTypes and defaultProps for functions 
> PropTypes were deprecated in [April 2017 (v15.5.0)](https://legacy.reactjs.org/blog/2017/04/07/react-v15.5.0.html#new-deprecation-warnings).
> 
> In React 19, we’re removing the propType checks from the React package, and using them will be silently ignored. If you’re using propTypes, we recommend migrating to TypeScript or another type-checking solution.
> 
> We’re also removing defaultProps from function components in place of ES6 default parameters. Class components will continue to support defaultProps since there is no ES6 alternative.

This PR solve this