### PR TITLE
Fix #84 by removing deprecated SafeAreaView

### DIFF
--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -29,7 +29,6 @@ import {
   TouchableWithoutFeedback,
   Text,
   Platform,
-  SafeAreaView,
   ScrollView,
   StyleProp,
   ViewStyle,
@@ -232,34 +231,32 @@ const Dialog = (props: DialogPropsType): JSX.Element => {
             },
             overlayStyle,
           ]}>
-          <SafeAreaView style={{flex: 1}}>
-            {renderOutsideTouchable()}
+          {renderOutsideTouchable()}
 
-            <View
-              style={[
-                {
-                  backgroundColor: dialogBackgroundColor,
-                  width: '100%',
-                  maxHeight: '100%',
-                  shadowOpacity: 0.24,
-                  borderRadius: dialogBorderRadius,
-                  elevation: 4,
-                  shadowOffset: {
-                    height: 4,
-                    width: 2,
-                  },
+          <View
+            style={[
+              {
+                backgroundColor: dialogBackgroundColor,
+                width: '100%',
+                maxHeight: '100%',
+                shadowOpacity: 0.24,
+                borderRadius: dialogBorderRadius,
+                elevation: 4,
+                shadowOffset: {
+                  height: 4,
+                  width: 2,
                 },
-                dialogStyle,
-              ]}>
-              {renderTitle()}
+              },
+              dialogStyle,
+            ]}>
+            {renderTitle()}
 
-              {renderContent()}
+            {renderContent()}
 
-              {renderButtons()}
-            </View>
+            {renderButtons()}
+          </View>
 
-            {renderOutsideTouchable()}
-          </SafeAreaView>
+          {renderOutsideTouchable()}
         </View>
       </ScrollView>
     </Modal>


### PR DESCRIPTION
Fixes #84 by removing the now-deprecated `SafeAreaView` that I added in PR #64.

This is a breaking change, as some dialogs will now extend behind camera cutouts and other system-reserved screen areas!

If this happens, users of this library can install https://github.com/AppAndFlow/react-native-safe-area-context and set the padding of the dialog's `overlayStyle` to at least the values provided by the `useSafeAreaInsets()` hook. For example:

```
const insets = useSafeAreaInsets();

[...]

<ConfirmDialog
[...]
  overlayStyle={{
    paddingBottom: insets.bottom + 24,
    paddingTop: insets.top + 24,
    paddingLeft: insets.left + 24,
    paddingRight: insets.right + 24
  }}>
```